### PR TITLE
Update tile URL, fix bug where no data was displayed

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -8,11 +8,13 @@ $.getJSON('http://data.seattle.gov/api/views/kzjm-xkqj/rows.json?jsonp=?&max_row
   }).addTo(map);
 
   $.each(results.data, function(index, value) {
-    var date = new Date(value[10]*1000);
-    var moment_date = moment(date).format("h:mm a, MMM D, YYYY")
+    if (value[11] && value[12]) {
+      var date = new Date(value[10]*1000);
+      var moment_date = moment(date).format("h:mm a, MMM D, YYYY");
 
-    L.marker([value[11], value[12]]).addTo(map)
-    .bindPopup('<h6>' + value[9] + '</h6>' + value[8] + '<br>' + moment_date );
+      L.marker([value[11], value[12]]).addTo(map)
+      .bindPopup('<h6>' + value[9] + '</h6>' + value[8] + '<br>' + moment_date );
+    }
   });
 
 });

--- a/js/app.js
+++ b/js/app.js
@@ -3,7 +3,7 @@ $.getJSON('http://data.seattle.gov/api/views/kzjm-xkqj/rows.json?jsonp=?&max_row
 
   var map = L.map('map').setView([47.6097, -122.3331], 11);
 
-  L.tileLayer('http://otile1.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.png', {
+  L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
       attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors'
   }).addTo(map);
 


### PR DESCRIPTION
The tile server you're using has been out of commission since July 11th, so I updated this to use openstreetmap.org tiles. Also, I noticed that any data points without latitude or longitude (which occasionally occur) cause no data to display, so I fixed that as well.

On a somewhat unrelated note, it says on the page that "future versions should include ways to browse the dispatches by time and location" and I happen to be somewhat familiar with this data. I helped make a project using it which has some browsing capabilities, which can be viewed [here](https://zmbc.shinyapps.io/final_project/). This was written in R but I'd totally be open to helping write some of that functionality in JS.
